### PR TITLE
Add plan_replace_multiple, ReplaceMultiplePlan

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0-alpha-9
+current_version = 0.4.0-alpha-10
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*)-(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}-{build}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sql-athame"
-version = "0.4.0-alpha-9"
+version = "0.4.0-alpha-10"
 description = "Python tool for slicing and dicing SQL"
 authors = ["Brian Downing <bdowning@lavos.net>"]
 license = "MIT"

--- a/sql_athame/__init__.py
+++ b/sql_athame/__init__.py
@@ -1,2 +1,2 @@
 from .base import Fragment, sql
-from .dataclasses import ColumnInfo, ModelBase
+from .dataclasses import ColumnInfo, ModelBase, ReplaceMultiplePlan


### PR DESCRIPTION
To allow control over execution order for multiple dependent tables.